### PR TITLE
fix: correct groupData null bug

### DIFF
--- a/src/runnerHtml.js
+++ b/src/runnerHtml.js
@@ -34,9 +34,9 @@ const runner = function (code, options) {
           description,
           severity,
           code,
-          groupData = {}
         } = item;
-    
+        const groupData = item.groupData || {};
+
         const cleanedItem = {};
         if (element) cleanedItem.element = element;
         if (message) cleanedItem.message = message;
@@ -49,13 +49,13 @@ const runner = function (code, options) {
         if (groupData.example_after) cleanedItem.example_after = groupData.example_after;
         if (code) cleanedItem.code = code.split('_')[0].split(',')[0];
 
-    
+
         return cleanedItem;
       });
-    
+
       resolve(cleanedData);
     })
-    
+
       .catch((error) => reject(error));
   });
 };

--- a/src/runnerUrl.js
+++ b/src/runnerUrl.js
@@ -33,8 +33,8 @@ const runner = function (code, options) {
             selector,
             component,
             issue_category_name,
-            groupData = {}
           } = item;
+          const groupData = item.groupData || {};
 
           const cleanedItem = {};
 


### PR DESCRIPTION
This change prevents an error being thrown when the API assigns a `null` value to `groupData`. In that case, the default value was not being assigned, the `null` value remained, and an error was thrown when the subsequent code attempted to read a property such as `why_issue` of `null`.